### PR TITLE
Update Manifest file from version 2 to version 3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ to install this extension, you should:
 7. Turn on the extension
 8. You can find the extension next to the address bar, with the e-satisfaction logo
 
+##  Browser Compatibility & Requirements
+
+This extension uses [Manifest V3](https://developer.chrome.com/docs/extensions/develop/migrate/what-is-mv3), which is used by modern Chromium-based browsers.
+
+The extension has been **tested** on the following browsers:
+
+| **Browser**         | **Tested** |
+|:-------------------:|:----------:|
+| Google Chrome       |    Yes     |
+| Microsoft Edge      |    Yes     |
+| Brave               |    Yes     |
+| Opera               |    Yes     |
+
+>  **Note**: The extension requires a Chromium-based browser with **version 88 or higher**. It may also work on other compatible browsers but it has not been explicitly tested there.
+
 ## Usage
 
 To test the e-satisfaction Integration on your website, you can follow these steps:

--- a/manifest.json
+++ b/manifest.json
@@ -16,9 +16,9 @@
             ]
         }
     ],
-    "browser_action": {
+    "action": {
         "default_icon": "icon.png",
         "default_popup": "popup.html"
     },
-    "manifest_version": 2
+    "manifest_version": 3
 }


### PR DESCRIPTION
**Update manifest_version from 2 to 3 for Chrome extension compatibility**

When attempting to install the extension in Chrome, the following error occurred:
<img width="700" height="400" alt="manifest-icon" src="https://github.com/user-attachments/assets/5ddaa464-e88e-494b-b625-0daf7525a0ed" />

This happens because Chrome no longer supports extensions using manifest_version: 2. To fix this issue and ensure smooth installation and functionality, the manifest_version was updated to 3.

Additionally, the manifest structure was adjusted to comply with Manifest V3 requirements, including replacing the **"browser_action"** field with **"action"**, as required by the new specification.

References:
- [Manifest V3 migration guide](https://developer.chrome.com/docs/extensions/develop/migrate)
- [Manifest V3 – Changes in the manifest file](https://developer.chrome.com/docs/extensions/develop/migrate/manifest)
- [Chrome Extension APIs – `action`](https://developer.chrome.com/docs/extensions/reference/api/action)